### PR TITLE
Tweaks regarding crafting recipes

### DIFF
--- a/acacia_planks_from_acacia_beam.json
+++ b/acacia_planks_from_acacia_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:acacia_beam"}], "result":{"item":"minecraft:acacia_planks","count":4}, "group":"plank_recycle"}

--- a/acacia_planks_from_acacia_panels.json
+++ b/acacia_planks_from_acacia_panels.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:acacia_small_beam"}], "result":{"item":"minecraft:acacia_planks","count":1}, "group":"plank_recycle"}

--- a/acacia_planks_from_acacia_small_beam.json
+++ b/acacia_planks_from_acacia_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:acacia_small_beam"}], "result":{"item":"minecraft:acacia_planks","count":1}, "group":"plank_recycle"}

--- a/acacia_small_beam.json
+++ b/acacia_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shaped","pattern":["#","#"],"key":{"#":{"item":"minecraft:acacia_log"}},"result":{"item":"druidcraft:acacia_small_beam","count":8},"group":"small_beams"}

--- a/birch_planks_from_birch_beam.json
+++ b/birch_planks_from_birch_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:birch_beam"}], "result":{"item":"minecraft:birch_planks","count":4}, "group":"plank_recycle"}

--- a/birch_planks_from_birch_panels.json
+++ b/birch_planks_from_birch_panels.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:birch_small_beam"}],"result":{"item":"minecraft:birch_planks","count":1}, "group":"plank_recycle"}

--- a/birch_planks_from_birch_small_beam.json
+++ b/birch_planks_from_birch_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:birch_small_beam"}],"result":{"item":"minecraft:birch_planks","count":1}, "group":"plank_recycle"}

--- a/birch_small_beam.json
+++ b/birch_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shaped","pattern":["#","#"],"key":{"#":{"item":"minecraft:birch_log"}},"result":{"item":"druidcraft:birch_small_beam","count":8},"group":"small_beams"}

--- a/compat/farmersdelight/cutting/darkwood_door.json
+++ b/compat/farmersdelight/cutting/darkwood_door.json
@@ -1,0 +1,23 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "druidcraft:darkwood_door"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool",
+    "tool": "axe"
+  },
+  "result": [
+    {
+      "item": "druidcraft:darkwood_planks"
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "druidcraft"
+    }
+  ]
+}

--- a/compat/farmersdelight/cutting/darkwood_log.json
+++ b/compat/farmersdelight/cutting/darkwood_log.json
@@ -1,0 +1,27 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "druidcraft:darkwood_log"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool",
+    "tool": "axe"
+  },
+  "result": [
+    {
+      "item": "farmersdelight:tree_bark"
+      },
+      {
+      "item": "druidcraft:stripped_darkwood_log"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "druidcraft"
+    }
+  ]
+}

--- a/compat/farmersdelight/cutting/darkwood_sign.json
+++ b/compat/farmersdelight/cutting/darkwood_sign.json
@@ -1,0 +1,23 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "druidcraft:darkwood_sign"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool",
+    "tool": "axe"
+  },
+  "result": [
+    {
+      "item": "druidcraft:darkwood_planks"
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "druidcraft"
+    }
+  ]
+}

--- a/compat/farmersdelight/cutting/darkwood_trapdoor.json
+++ b/compat/farmersdelight/cutting/darkwood_trapdoor.json
@@ -1,0 +1,23 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "druidcraft:darkwood_trapdoor"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool",
+    "tool": "axe"
+  },
+  "result": [
+    {
+      "item": "druidcraft:darkwood_planks"
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "druidcraft"
+    }
+  ]
+}

--- a/compat/farmersdelight/cutting/darkwood_wood.json
+++ b/compat/farmersdelight/cutting/darkwood_wood.json
@@ -1,0 +1,27 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "druidcraft:darkwood_wood"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool",
+    "tool": "axe"
+  },
+  "result": [
+    {
+      "item": "farmersdelight:tree_bark"
+      },
+      {
+      "item": "druidcraft:stripped_darkwood_wood"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "druidcraft"
+    }
+  ]
+}

--- a/compat/farmersdelight/cutting/elder_door.json
+++ b/compat/farmersdelight/cutting/elder_door.json
@@ -1,0 +1,23 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "druidcraft:elder_door"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool",
+    "tool": "axe"
+  },
+  "result": [
+    {
+      "item": "druidcraft:elder_planks"
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "druidcraft"
+    }
+  ]
+}

--- a/compat/farmersdelight/cutting/elder_log.json
+++ b/compat/farmersdelight/cutting/elder_log.json
@@ -1,0 +1,27 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "druidcraft:elder_log"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool",
+    "tool": "axe"
+  },
+  "result": [
+    {
+      "item": "farmersdelight:tree_bark"
+      },
+      {
+      "item": "druidcraft:stripped_elder_log"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "druidcraft"
+    }
+  ]
+}

--- a/compat/farmersdelight/cutting/elder_sign.json
+++ b/compat/farmersdelight/cutting/elder_sign.json
@@ -1,0 +1,23 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "druidcraft:elder_sign"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool",
+    "tool": "axe"
+  },
+  "result": [
+    {
+      "item": "druidcraft:elder_planks"
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "druidcraft"
+    }
+  ]
+}

--- a/compat/farmersdelight/cutting/elder_trapdoor.json
+++ b/compat/farmersdelight/cutting/elder_trapdoor.json
@@ -1,0 +1,23 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "druidcraft:elder_trapdoor"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool",
+    "tool": "axe"
+  },
+  "result": [
+    {
+      "item": "druidcraft:elder_planks"
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "druidcraft"
+    }
+  ]
+}

--- a/compat/farmersdelight/cutting/elder_wood.json
+++ b/compat/farmersdelight/cutting/elder_wood.json
@@ -1,0 +1,27 @@
+{
+  "type": "farmersdelight:cutting",
+  "ingredients": [
+    {
+      "item": "druidcraft:elder_wood"
+    }
+  ],
+  "tool": {
+    "type": "farmersdelight:tool",
+    "tool": "axe"
+  },
+  "result": [
+    {
+      "item": "farmersdelight:tree_bark"
+      },
+      {
+      "item": "druidcraft:stripped_elder_wood"
+    }
+  ],
+  "sound": "minecraft:item.axe.strip",
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "druidcraft"
+    }
+  ]
+}

--- a/dark_oak_planks_from_dark_oak_beam.json
+++ b/dark_oak_planks_from_dark_oak_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:dark_oak_beam"}], "result":{"item":"minecraft:dark_oak_planks","count":4}, "group":"plank_recycle"}

--- a/dark_oak_planks_from_dark_oak_panels.json
+++ b/dark_oak_planks_from_dark_oak_panels.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:birch_small_beam"}],"result":{"item":"minecraft:birch_planks","count":1}, "group":"plank_recycle"}

--- a/dark_oak_planks_from_dark_oak_small_beam.json
+++ b/dark_oak_planks_from_dark_oak_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:birch_small_beam"}],"result":{"item":"minecraft:birch_planks","count":1}, "group":"plank_recycle"}

--- a/dark_oak_small_beam.json
+++ b/dark_oak_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shaped","pattern":["#","#"],"key":{"#":{"item":"minecraft:dark_oak_log"}},"result":{"item":"druidcraft:dark_oak_small_beam","count":8},"group":"small_beams"}

--- a/darkwood_planks_from_darkwood_beam.json
+++ b/darkwood_planks_from_darkwood_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:darkwood_beam"}], "result":{"item":"druidcraft:darkwood_planks","count":4}, "group":"plank_recycle"}

--- a/darkwood_planks_from_darkwood_panels.json
+++ b/darkwood_planks_from_darkwood_panels.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:darkwood_small_beam"}],"result":{"item":"druidcraft:darkwood_planks","count":1}, "group":"plank_recycle"}

--- a/darkwood_planks_from_darkwood_small_beam.json
+++ b/darkwood_planks_from_darkwood_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:darkwood_small_beam"}],"result":{"item":"druidcraft:darkwood_planks","count":1}, "group":"plank_recycle"}

--- a/darkwood_small_beam.json
+++ b/darkwood_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shaped","pattern":["#","#"],"key":{"#":{"item":"druidcraft:darkwood_log"}},"result":{"item":"druidcraft:darkwood_small_beam","count":8},"group":"small_beams"}

--- a/elder_planks_from_elder_beam.json
+++ b/elder_planks_from_elder_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:elder_beam"}], "result":{"item":"druidcraft:elder_planks","count":4}, "group":"plank_recycle"}

--- a/elder_planks_from_elder_panels.json
+++ b/elder_planks_from_elder_panels.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:elder_small_beam"}],"result":{"item":"druidcraft:elder_planks","count":1}, "group":"plank_recycle"}

--- a/elder_planks_from_elder_small_beam.json
+++ b/elder_planks_from_elder_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:elder_small_beam"}],"result":{"item":"druidcraft:elder_planks","count":1}, "group":"plank_recycle"}

--- a/elder_small_beam.json
+++ b/elder_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shaped","pattern":["#","#"],"key":{"#":{"item":"druidcraft:elder_log"}},"result":{"item":"druidcraft:elder_small_beam","count":8},"group":"small_beams"}

--- a/jungle_planks_from_jungle_beam.json
+++ b/jungle_planks_from_jungle_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:jungle_beam"}], "result":{"item":"minecraft:jungle_planks","count":4}, "group":"plank_recycle"}

--- a/jungle_planks_from_jungle_panels.json
+++ b/jungle_planks_from_jungle_panels.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:birch_small_beam"}],"result":{"item":"minecraft:birch_planks","count":1}, "group":"plank_recycle"}

--- a/jungle_planks_from_jungle_small_beam.json
+++ b/jungle_planks_from_jungle_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:birch_small_beam"}],"result":{"item":"minecraft:birch_planks","count":1}, "group":"plank_recycle"}

--- a/jungle_small_beam.json
+++ b/jungle_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shaped","pattern":["#","#"],"key":{"#":{"item":"minecraft:jungle_log"}},"result":{"item":"druidcraft:jungle_small_beam","count":8},"group":"small_beams"}

--- a/oak_planks_from_oak_beam.json
+++ b/oak_planks_from_oak_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:oak_beam"}], "result":{"item":"minecraft:oak_planks","count":4}, "group":"plank_recycle"}

--- a/oak_planks_from_oak_panels.json
+++ b/oak_planks_from_oak_panels.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:oak_small_beam"}],"result":{"item":"minecraft:oak_planks","count":1}, "group":"plank_recycle"}

--- a/oak_planks_from_oak_small_beam.json
+++ b/oak_planks_from_oak_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:oak_small_beam"}],"result":{"item":"minecraft:oak_planks","count":1}, "group":"plank_recycle"}

--- a/oak_small_beam.json
+++ b/oak_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shaped","pattern":["#","#"],"key":{"#":{"item":"minecraft:oak_log"}},"result":{"item":"druidcraft:oak_small_beam","count":8},"group":"small_beams"}

--- a/spruce_planks_from_spruce_beam.json
+++ b/spruce_planks_from_spruce_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:spruce_beam"}], "result":{"item":"minecraft:spruce_planks","count":4}, "group":"plank_recycle"}

--- a/spruce_planks_from_spruce_panels.json
+++ b/spruce_planks_from_spruce_panels.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:spruce_small_beam"}],"result":{"item":"minecraft:spruce_planks","count":1}, "group":"plank_recycle"}

--- a/spruce_planks_from_spruce_small_beam.json
+++ b/spruce_planks_from_spruce_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shapeless","ingredients":[{"item":"druidcraft:spruce_small_beam"}],"result":{"item":"minecraft:spruce_planks","count":1}, "group":"plank_recycle"}

--- a/spruce_small_beam.json
+++ b/spruce_small_beam.json
@@ -1,0 +1,1 @@
+{"type":"minecraft:crafting_shaped","pattern":["#","#"],"key":{"#":{"item":"minecraft:spruce_log"}},"result":{"item":"druidcraft:spruce_small_beam","count":8},"group":"small_beams"}


### PR DESCRIPTION
- Panels, beams and small beams can now be used to craft their respective planks types, allowing players to recycle the blocks that they won't use. Panels and small beams can be crafted into 1 planks, while beams can be crafted into 4 planks, similarly with logs.
- Crafting small beams now yields 8 of them, rather than just 2. This is to make the recipes more proportional with the quantity of materials used.
- Added support for Farmer's Delight cutting board recipes.